### PR TITLE
bump setup-python action

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -43,7 +43,7 @@ runs:
         fetch-depth: "100"
     - run: git fetch --prune --tags --unshallow
       shell: bash -l {0}
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
     - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
I'd rather not have this action install Python since anyway it's available from the conda environment. That's future work though.