### PR TITLE
Add option to use mamba for install

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -21,7 +21,9 @@ This action handles the setup and caching of environments used for testing on va
   Whether to install openGL
 - playwright: bool (default: false)
   Whether to install playwright
-  
+- conda-mamba: 'conda' / 'mamba' (default: 'conda')
+  Whether to use conda or mamba for installing
+
 ## Outputs
 
 - cache-hit:

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -80,7 +80,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.ENVS_PATH }}
-        key: ${{ inputs.name  }}-${{ runner.os }}-conda-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
+        key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.conda-mamba }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -86,6 +86,8 @@ runs:
     - if: inputs.conda-mamba == 'mamba'
       run: |
         conda install mamba -c conda-forge -n base
+        conda run -n base mamba init
+        echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -99,8 +99,8 @@ runs:
           if [ "$channel" = "nodefaults" ]
           then
             echo "Remove defaults channel"
-            conda config --remove channels defaults || echo nodefault
-            conda config --env --remove channels defaults || echo nodefault
+            conda config --remove channels defaults
+            conda config --env --remove channels defaults
           else
             echo "Add channel $channel"
             conda config --env --append channels ${channel}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -50,7 +50,7 @@ runs:
       with:
         fetch-depth: "100"
     - run: git fetch --prune --tags --unshallow
-      shell: bash -l {0}
+      shell: bash -el {0}
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
@@ -62,30 +62,30 @@ runs:
       # - if: inputs.conda-update == 'true'
       #   run: |
       #     conda update -c defaults -n base conda
-      # shell: bash -l {0}
+      # shell: bash -el {0}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: runner.os == 'Windows'
       run: echo "ENVS_PATH=${{ format('{0}\{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: runner.os != 'Windows'
       run: echo "ENVS_PATH=${{ format('{0}/{1}', env.CONDA, 'envs') }}" >> $GITHUB_ENV
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: inputs.cache == 'true'
       uses: actions/cache@v3
       with:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-conda-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
-    - run: |
-        conda install mamba -y
-        mamba init
-      shell: bash -l {0}
-      id: mamba
+    # - run: |
+    #     conda install mamba -y
+    #     mamba init
+      # shell: bash -el {0}
+      # id: mamba
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
         mamba install nodejs
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: steps.cache.outputs.cache-hit != 'true'
       run: |
         conda create -n test-environment
@@ -105,13 +105,13 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        conda install python=${{ inputs.python-version }} pyctdev mamba
-      shell: bash -l {0}
+        conda install python=${{ inputs.python-version }} pyctdev # mamba
+      shell: bash -el {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'
       run: |
         conda activate test-environment
         pip install -e . --no-deps --no-build-isolation
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
       # Need || echo "Keep going" and pip install again to deal with
       # when pyctdev updates CPython itself. Dangerous as that could
@@ -120,34 +120,34 @@ runs:
         conda activate test-environment
         doit develop_install ${{ inputs.envs }} --conda-mode=mamba || echo "Keep going"
         pip install -e . --no-deps --no-build-isolation
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Windows'
       run: |
         git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
         powershell gl-ci-helpers/appveyor/install_opengl.ps1
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Linux'
       run: |
         sudo apt-get install libglu1-mesa
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x24
         sleep 3
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Linux' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
         conda activate test-environment
         mamba install mesalib
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: inputs.playwright == 'true' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
         conda activate test-environment
         pip install playwright pytest-playwright
-      shell: bash -l {0}
+      shell: bash -el {0}
     - if: inputs.playwright == 'true'
       run: |
         conda activate test-environment
         playwright install chromium
-      shell: bash -l {0}
+      shell: bash -el {0}
     - run: |
         conda activate test-environment
         doit env_capture
-      shell: bash -l {0}
+      shell: bash -el {0}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -66,9 +66,8 @@ runs:
         miniforge-variant: Mambaforge
         channels: conda-forge
         use-mamba: true
-        # auto-update-conda is needed when caching to pull the latest index
-        auto-update-conda: ${{ inputs.conda-update == 'true' || inputs.cache == 'true' }}
-        use-only-tar-bz2: ${{ inputs.cache }}
+        auto-update-conda: ${{ inputs.conda-update }}
+        # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: runner.os == 'Windows'
@@ -83,10 +82,6 @@ runs:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.conda-mamba }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
-    - if: inputs.conda-update == 'true' || inputs.cache == 'true'
-      run: |
-        ${{ inputs.conda-mamba }} update conda -n base
-      shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
         ${{ inputs.conda-mamba }} install nodejs

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -67,7 +67,7 @@ runs:
         channels: conda-forge
         use-mamba: true
         auto-update-conda: ${{ inputs.conda-update }}
-        use-only-tar-bz2: ${{ inputs.cache }}
+        # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest holoviews
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: runner.os == 'Windows'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -64,9 +64,8 @@ runs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
-        channels: conda-forge,defaults
+        channels: defaults
         auto-update-conda: ${{ inputs.conda-update }}
-        mamba-version: "1.0"
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
@@ -84,9 +83,8 @@ runs:
       id: cache
     - if: inputs.conda-mamba == 'mamba'
       run: |
-        conda run -n base conda list mamba
-        conda install mamba -c conda-forge -n base
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
+        conda install mamba=1 -c conda-forge -n base
         conda run -n base mamba init --all
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -56,7 +56,7 @@ runs:
         python-version: ${{ inputs.python-version }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniforge-variant: Miniforge3
+        miniforge-variant: Mambaforge
         channels: conda-forge
         use-mamba: true
       # - if: inputs.conda-update == 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -66,7 +66,7 @@ runs:
         miniconda-version: "latest"
         channels: conda-forge,defaults
         auto-update-conda: ${{ inputs.conda-update }}
-        mamba-version: "*"
+        mamba-version: "1.0"
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -77,6 +77,9 @@ runs:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-conda-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
+    - run: |
+        conda install mamba -y
+      id: mamba
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
         mamba install nodejs

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -56,7 +56,7 @@ runs:
         python-version: ${{ inputs.python-version }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniconda-version: "latest"
+        miniforge-variant: Miniforge3
         channels: conda-forge
         use-mamba: true
       # - if: inputs.conda-update == 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -64,7 +64,6 @@ runs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
-        channels: defaults
         auto-update-conda: ${{ inputs.conda-update }}
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -79,6 +79,7 @@ runs:
       id: cache
     - run: |
         conda install mamba -y
+        mamba init
       shell: bash -l {0}
       id: mamba
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -79,6 +79,7 @@ runs:
       id: cache
     - run: |
         conda install mamba -y
+      shell: bash -l {0}
       id: mamba
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -94,8 +94,8 @@ runs:
           if [ "$channel" = "nodefaults" ]
           then
             echo "Remove defaults channel"
-            conda config --remove channels defaults
-            conda config --env --remove channels defaults
+            conda config --remove channels defaults || echo run
+            conda config --env --remove channels defaults || echo run
           else
             echo "Add channel $channel"
             conda config --env --append channels ${channel}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -26,19 +26,23 @@ inputs:
   nodejs:
     description: Whether to install nodejs in the base environment
     required: false
-    default: 'false'
+    default: "false"
   cache:
     description: Whether to enable caching
     required: false
-    default: 'false'
+    default: "false"
   opengl:
     description: Whether to install openGL
     required: false
-    default: 'false'
+    default: "false"
   playwright:
     description: Whether to install playwright
     required: false
     default: 'false'
+  conda-mamba:
+    description: Whether to use conda or mamba
+    required: false
+    default: "mamba"
 outputs:
   cache-hit:
     description: Whether the cache was hit
@@ -79,7 +83,7 @@ runs:
       id: cache
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
-        mamba install nodejs
+        ${{ inputs.conda-mamba }} install nodejs
       shell: bash -el {0}
     - if: steps.cache.outputs.cache-hit != 'true'
       run: |
@@ -100,7 +104,7 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        mamba install python=${{ inputs.python-version }} pyctdev
+        ${{ inputs.conda-mamba }} install python=${{ inputs.python-version }} pyctdev
       shell: bash -el {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'
       run: |
@@ -113,7 +117,7 @@ runs:
       # hide other issues.
       run: |
         conda activate test-environment
-        doit develop_install ${{ inputs.envs }} --conda-mode=mamba || echo "Keep going"
+        doit develop_install ${{ inputs.envs }} --conda-mode=${{ inputs.conda-mamba }} || echo "Keep going"
         pip install -e . --no-deps --no-build-isolation
       shell: bash -el {0}
     - if: inputs.opengl == 'true' && runner.os == 'Windows'
@@ -130,7 +134,7 @@ runs:
     - if: inputs.opengl == 'true' && runner.os == 'Linux' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
         conda activate test-environment
-        mamba install mesalib
+        ${{ inputs.conda-mamba }} install mesalib
       shell: bash -el {0}
     - if: inputs.playwright == 'true' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -66,8 +66,8 @@ runs:
         miniforge-variant: Mambaforge
         channels: conda-forge
         use-mamba: true
-        auto-update-conda: ${{ inputs.conda-update }}
-        # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest holoviews
+        auto-update-conda: ${{ inputs.conda-update || inputs.cache }}
+        use-only-tar-bz2: ${{ inputs.cache }}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: runner.os == 'Windows'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -83,6 +83,10 @@ runs:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.conda-mamba }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
+    - if: inputs.conda-mamba == 'mamba'
+      run: |
+        conda install mamba -c conda-forge -n base
+      shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
         ${{ inputs.conda-mamba }} install nodejs

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -64,7 +64,7 @@ runs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
-        channels: defaults
+        channels: conda-forge,defaults
         auto-update-conda: ${{ inputs.conda-update }}
         mamba-version: "*"
         python-version: 3.8  # For the base?
@@ -85,6 +85,7 @@ runs:
       id: cache
     - if: inputs.conda-mamba == 'mamba'
       run: |
+        conda list mamba
         conda install mamba -c conda-forge -n base
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
         conda run -n base mamba init --all

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -66,7 +66,8 @@ runs:
         miniforge-variant: Mambaforge
         channels: conda-forge
         use-mamba: true
-        auto-update-conda: ${{ inputs.conda-update || inputs.cache }}
+        # auto-update-conda is needed when caching to pull the latest index
+        auto-update-conda: ${{ inputs.conda-update == 'true' || inputs.cache == 'true' }}
         use-only-tar-bz2: ${{ inputs.cache }}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
@@ -82,6 +83,10 @@ runs:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.conda-mamba }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
+    - if: inputs.conda-update == 'true' || inputs.cache == 'true'
+      run: |
+        ${{ inputs.conda-mamba }} update conda -n base
+      shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
         ${{ inputs.conda-mamba }} install nodejs

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -63,10 +63,8 @@ runs:
         python-version: ${{ inputs.python-version }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        # miniforge-variant: Mambaforge
         miniconda-version: "latest"
-        channels: conda-forge
-        use-mamba: true
+        channels: defaults
         auto-update-conda: ${{ inputs.conda-update }}
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
@@ -86,8 +84,8 @@ runs:
     - if: inputs.conda-mamba == 'mamba'
       run: |
         conda install mamba -c conda-forge -n base
-        conda run -n base mamba init
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
+        conda run -n base mamba init --all
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -67,7 +67,6 @@ runs:
         channels: conda-forge,defaults
         auto-update-conda: ${{ inputs.conda-update }}
         mamba-version: "*"
-        python-version: 3.8  # For the base?
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
@@ -85,7 +84,7 @@ runs:
       id: cache
     - if: inputs.conda-mamba == 'mamba'
       run: |
-        conda list mamba
+        conda run -n base conda list mamba
         conda install mamba -c conda-forge -n base
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
         conda run -n base mamba init --all

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -80,7 +80,7 @@ runs:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-${{ inputs.conda-mamba }}-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
-    - if: inputs.conda-mamba == 'mamba'
+    - if: inputs.conda-mamba == 'mamba' && steps.cache.outputs.cache-hit != 'true'
       run: |
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
         conda install mamba -c conda-forge -n base

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -68,7 +68,6 @@ runs:
         use-mamba: true
         auto-update-conda: ${{ inputs.conda-update }}
         use-only-tar-bz2: true
-      shell: bash -el {0}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: runner.os == 'Windows'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -63,7 +63,8 @@ runs:
         python-version: ${{ inputs.python-version }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        miniforge-variant: Mambaforge
+        # miniforge-variant: Mambaforge
+        miniconda-version: "latest"
         channels: conda-forge
         use-mamba: true
         auto-update-conda: ${{ inputs.conda-update }}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -67,7 +67,7 @@ runs:
         channels: conda-forge
         use-mamba: true
         auto-update-conda: ${{ inputs.conda-update }}
-        use-only-tar-bz2: true
+        use-only-tar-bz2: ${{ inputs.cache }}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: runner.os == 'Windows'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -105,7 +105,7 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        mamba install python=${{ inputs.python-version }} pyctdev
+        conda install python=${{ inputs.python-version }} pyctdev mamba
       shell: bash -l {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -66,6 +66,8 @@ runs:
         miniconda-version: "latest"
         channels: defaults
         auto-update-conda: ${{ inputs.conda-update }}
+        mamba-version: "*"
+        python-version: 3.8  # For the base?
         # use-only-tar-bz2: ${{ inputs.cache }}  # Does not give latest version
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -59,10 +59,10 @@ runs:
         miniconda-version: "latest"
         channels: conda-forge
         use-mamba: true
-    - if: inputs.conda-update == 'true'
-      run: |
-        conda update -c defaults -n base conda
-      shell: bash -l {0}
+      # - if: inputs.conda-update == 'true'
+      #   run: |
+      #     conda update -c defaults -n base conda
+      # shell: bash -l {0}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -l {0}
     - if: runner.os == 'Windows'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -90,8 +90,8 @@ runs:
           if [ "$channel" = "nodefaults" ]
           then
             echo "Remove defaults channel"
-            conda config --remove channels defaults
-            conda config --env --remove channels defaults
+            conda config --remove channels defaults || echo nodefault
+            conda config --env --remove channels defaults || echo nodefault
           else
             echo "Add channel $channel"
             conda config --env --append channels ${channel}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -26,15 +26,15 @@ inputs:
   nodejs:
     description: Whether to install nodejs in the base environment
     required: false
-    default: "false"
+    default: 'false'
   cache:
     description: Whether to enable caching
     required: false
-    default: "false"
+    default: 'false'
   opengl:
     description: Whether to install openGL
     required: false
-    default: "false"
+    default: 'false'
   playwright:
     description: Whether to install playwright
     required: false
@@ -42,7 +42,10 @@ inputs:
   conda-mamba:
     description: Whether to use conda or mamba
     required: false
-    default: "mamba"
+    default: "conda"
+    options:
+      - conda
+      - mamba
 outputs:
   cache-hit:
     description: Whether the cache was hit
@@ -63,10 +66,10 @@ runs:
         miniforge-variant: Mambaforge
         channels: conda-forge
         use-mamba: true
-      # - if: inputs.conda-update == 'true'
-      #   run: |
-      #     conda update -c defaults -n base conda
-      # shell: bash -el {0}
+    - if: inputs.conda-update == 'true'
+      run: |
+        conda update -c defaults -n base conda
+      shell: bash -el {0}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}
     - if: runner.os == 'Windows'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -77,11 +77,6 @@ runs:
         path: ${{ env.ENVS_PATH }}
         key: ${{ inputs.name  }}-${{ runner.os }}-conda-${{ inputs.python-version }}-${{ hashFiles('setup.py') }}-${{ env.TODAY }}
       id: cache
-    # - run: |
-    #     conda install mamba -y
-    #     mamba init
-      # shell: bash -el {0}
-      # id: mamba
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
         mamba install nodejs
@@ -95,8 +90,8 @@ runs:
           if [ "$channel" = "nodefaults" ]
           then
             echo "Remove defaults channel"
-            conda config --remove channels defaults || echo run
-            conda config --env --remove channels defaults || echo run
+            conda config --remove channels defaults
+            conda config --env --remove channels defaults
           else
             echo "Add channel $channel"
             conda config --env --append channels ${channel}
@@ -105,7 +100,7 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        conda install python=${{ inputs.python-version }} pyctdev # mamba
+        mamba install python=${{ inputs.python-version }} pyctdev
       shell: bash -el {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'
       run: |

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -84,7 +84,7 @@ runs:
     - if: inputs.conda-mamba == 'mamba'
       run: |
         echo "MAMBA_NO_BANNER=1" >> $GITHUB_ENV
-        conda install mamba=1 -c conda-forge -n base
+        conda install mamba -c conda-forge -n base
         conda run -n base mamba init --all
       shell: bash -el {0}
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -57,6 +57,8 @@ runs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
+        channels: conda-forge
+        use-mamba: true
     - if: inputs.conda-update == 'true'
       run: |
         conda update -c defaults -n base conda
@@ -77,7 +79,7 @@ runs:
       id: cache
     - if: inputs.nodejs == 'true' && steps.cache.outputs.cache-hit != 'true'
       run: |
-        conda install nodejs
+        mamba install nodejs
       shell: bash -l {0}
     - if: steps.cache.outputs.cache-hit != 'true'
       run: |
@@ -98,7 +100,7 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        conda install python=${{ inputs.python-version }} pyctdev
+        mamba install python=${{ inputs.python-version }} pyctdev
       shell: bash -l {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'
       run: |
@@ -111,7 +113,7 @@ runs:
       # hide other issues.
       run: |
         conda activate test-environment
-        doit develop_install ${{ inputs.envs }}  || echo "Keep going"
+        doit develop_install ${{ inputs.envs }} --conda-mode=mamba || echo "Keep going"
         pip install -e . --no-deps --no-build-isolation
       shell: bash -l {0}
     - if: inputs.opengl == 'true' && runner.os == 'Windows'
@@ -128,7 +130,7 @@ runs:
     - if: inputs.opengl == 'true' && runner.os == 'Linux' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
         conda activate test-environment
-        conda install mesalib
+        mamba install mesalib
       shell: bash -l {0}
     - if: inputs.playwright == 'true' && (inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true')
       run: |
@@ -141,6 +143,6 @@ runs:
         playwright install chromium
       shell: bash -l {0}
     - run: |
-          conda activate test-environment
-          doit env_capture
+        conda activate test-environment
+        doit env_capture
       shell: bash -l {0}

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -42,10 +42,10 @@ inputs:
   conda-mamba:
     description: Whether to use conda or mamba
     required: false
-    default: "conda"
+    default: 'conda'
     options:
-      - conda
-      - mamba
+      - 'conda'
+      - 'mamba'
 outputs:
   cache-hit:
     description: Whether the cache was hit
@@ -66,9 +66,8 @@ runs:
         miniforge-variant: Mambaforge
         channels: conda-forge
         use-mamba: true
-    - if: inputs.conda-update == 'true'
-      run: |
-        conda update -c defaults -n base conda
+        auto-update-conda: ${{ inputs.conda-update }}
+        use-only-tar-bz2: true
       shell: bash -el {0}
     - run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
       shell: bash -el {0}


### PR DESCRIPTION
The main reason is that python 3.7 can't solve in 1.5 hours for holoviews and panel. 

Some notes:
- Change from `shell: bash -l {0}`  to `shell: bash -el {0}` is because it is mentioned [here](https://github.com/conda-incubator/setup-miniconda#important).
- The method for option was found [here](https://stackoverflow.com/a/73065956).