### PR TITLE
Install action: force git fetch

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -56,7 +56,9 @@ runs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: "100"
-    - run: git fetch --prune --tags --unshallow
+      # Forcing fetch to avoid 'would clobber existing tag', as the previous step
+      # fetches tags already.
+    - run: git fetch --prune --tags --unshallow --force
       shell: bash -el {0}
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
The action failed at the `git fetch` step on a docs deployment due to

>  ! [rejected]          v0.14.3rc2            -> v0.14.3rc2  (would clobber existing tag)

Forcing git fetch should resolve this.