### PR TITLE
Add nomkl to task

### DIFF
--- a/install/action.yaml
+++ b/install/action.yaml
@@ -115,7 +115,7 @@ runs:
         conda config --env --set channel_priority ${{ inputs.channel-priority }}
         conda config --show-sources
         conda info
-        ${{ inputs.conda-mamba }} install python=${{ inputs.python-version }} pyctdev
+        ${{ inputs.conda-mamba }} install python=${{ inputs.python-version }} pyctdev nomkl
       shell: bash -el {0}
     - if: inputs.cache == 'true' && steps.cache.outputs.cache-hit == 'true'
       run: |


### PR DESCRIPTION
I can see on Windows MKL is installed which is around ~180 MB. This can be avoided by installing the nomkl package.

`CONDA_SUBDIR=win-64 conda create -n tmp1111 numpy`. 